### PR TITLE
Add a system that allows us to propegate env vars through buildpacks

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -74,12 +74,13 @@ cd "$BUILD_DIR" || exit
 
 DOPPLER_TOKEN=$(cat $ENV_DIR/DOPPLER_TOKEN)
 
+# echo DOPPLER_TOKEN
+echo "Quick test: $DOPPLER_TOKEN"
+
 # Helper system to deal with heroku not dealing well with heroku-prebuild and yarn in the nodejs package
-echo "Checking if we have any TARGET_DOPPLER_VARS"
 TARGET_DOPPLER_VARS=$(cat $ENV_DIR/TARGET_DOPPLER_VARS)
 echo "TARGET_DOPPLER_VARS: $TARGET_DOPPLER_VARS"
 if [ -z "$TARGET_DOPPLER_VARS" ]; then
-  echo "TARGET_DOPPLER_VARS is blank"
   exit
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -76,8 +76,10 @@ if [ -f "$ENV_DIR/DOPPLER_TOKEN" ]; then
   export DOPPLER_TOKEN=$(cat $ENV_DIR/DOPPLER_TOKEN)
 fi
 
+
+
 # Helper system to deal with heroku not dealing well with heroku-prebuild and yarn in the nodejs package
-if [ -z "$ENV_DIR/TARGET_DOPPLER_VARS" ]; then
+if [ ! -f "$ENV_DIR/TARGET_DOPPLER_VARS" ]; then
   exit;
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -72,14 +72,16 @@ EOF
 
 cd "$BUILD_DIR" || exit
 
-export DOPPLER_TOKEN=$(cat $ENV_DIR/DOPPLER_TOKEN)
+if [ -f "$ENV_DIR/DOPPLER_TOKEN" ]; then
+  export DOPPLER_TOKEN=$(cat $ENV_DIR/DOPPLER_TOKEN)
 
 # Helper system to deal with heroku not dealing well with heroku-prebuild and yarn in the nodejs package
-TARGET_DOPPLER_VARS=$(cat $ENV_DIR/TARGET_DOPPLER_VARS)
-echo "TARGET_DOPPLER_VARS: $TARGET_DOPPLER_VARS"
-if [ -z "$TARGET_DOPPLER_VARS" ]; then
-  exit
+if [ -z "$ENV_DIR/TARGET_DOPPLER_VARS" ]; then
+  exit;
 fi
+
+TARGET_DOPPLER_VARS=$(cat $ENV_DIR/TARGET_DOPPLER_VARS)
+
 
 echo "Found TARGET_DOPPLER_VARS, attempting to extract and process..."
 BP_DIR=$(cd "$(dirname "${0:-}")"; cd ..; pwd)

--- a/bin/compile
+++ b/bin/compile
@@ -82,9 +82,8 @@ if [ ! -f "$ENV_DIR/TARGET_DOPPLER_VARS" ]; then
 fi
 
 TARGET_DOPPLER_VARS=$(cat $ENV_DIR/TARGET_DOPPLER_VARS)
-
-
 echo "Found TARGET_DOPPLER_VARS, attempting to extract and process..."
+
 BP_DIR=$(cd "$(dirname "${0:-}")"; cd ..; pwd)
 
 # So we have target_doppler_vars, lets split them out, then fetch and export the value from doppler
@@ -95,7 +94,3 @@ for VAR in $TARGET_DOPPLER_VARS; do
   # export the env var to >> $BP_DIR/export
   echo "export $VAR=$VALUE" >> "$BP_DIR/export"
 done
-
-
-
-

--- a/bin/compile
+++ b/bin/compile
@@ -82,6 +82,8 @@ if [ -z "$TARGET_DOPPLER_VARS" ]; then
 fi
 
 echo "Found TARGET_DOPPLER_VARS, attempting to extract and process..."
+BUILD_DIR=${1:-}
+BP_DIR=$(cd "$(dirname "${0:-}")"; cd ..; pwd)
 
 # So we have target_doppler_vars, lets split them out, then fetch and export the value from doppler
 IFS=',' # Set the Internal Field Separator to comma

--- a/bin/compile
+++ b/bin/compile
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # bin/compile <build-dir> <cache-dir> <env-dir>
 
 # Parse args
@@ -83,7 +83,13 @@ if [ -z "$TARGET_DOPPLER_VARS" ]; then
 echo "Found TARGET_DOPPLER_VARS, attempting to extract and process..."
 
 # So we have target_doppler_vars, lets split them out, then fetch and export the value from doppler
-IFS=',' read -ra VARS <<< "$TARGET_DOPPLER_VARS"
+IFS=',' # Set the Internal Field Separator to comma
+for VAR in $TARGET_DOPPLER_VARS; do # Iterate over the variables
+  echo "Fetching $VAR from doppler"
+  VALUE=$(doppler secrets get $VAR --plain)
+  # export the env var to >> $BP_DIR/export
+  echo "export $VAR=$VALUE" >> $BP_DIR/export
+done
 
 for VAR in "${VARS[@]}"; do
   echo "Fetching $VAR from doppler"

--- a/bin/compile
+++ b/bin/compile
@@ -72,7 +72,7 @@ EOF
 
 cd "$BUILD_DIR" || exit
 
-DOPPLER_TOKEN=$(cat $ENV_DIR/DOPPLER_TOKEN)
+export DOPPLER_TOKEN=$(cat $ENV_DIR/DOPPLER_TOKEN)
 
 # echo DOPPLER_TOKEN
 echo "Quick test: $DOPPLER_TOKEN"

--- a/bin/compile
+++ b/bin/compile
@@ -76,8 +76,6 @@ if [ -f "$ENV_DIR/DOPPLER_TOKEN" ]; then
   export DOPPLER_TOKEN=$(cat $ENV_DIR/DOPPLER_TOKEN)
 fi
 
-
-
 # Helper system to deal with heroku not dealing well with heroku-prebuild and yarn in the nodejs package
 if [ ! -f "$ENV_DIR/TARGET_DOPPLER_VARS" ]; then
   exit;
@@ -95,7 +93,7 @@ for VAR in $TARGET_DOPPLER_VARS; do
   echo "Fetching $VAR from doppler"
   VALUE=$($BUILD_DIR/vendor/doppler/doppler secrets get $VAR --plain)
   # export the env var to >> $BP_DIR/export
-  echo "export $VAR=$VALUE" > "$BP_DIR/export"
+  echo "export $VAR=$VALUE" >> "$BP_DIR/export"
 done
 
 

--- a/bin/compile
+++ b/bin/compile
@@ -74,4 +74,22 @@ cd "$BUILD_DIR" || exit
 
 DOPPLER_TOKEN=$(cat $ENV_DIR/DOPPLER_TOKEN)
 
+# Helper system to deal with heroku not dealing well with heroku-prebuild and yarn in the nodejs package
+TARGET_DOPPLER_VARS=$(cat $ENV_DIR/TARGET_DOPPLER_VARS)
+if [ -z "$TARGET_DOPPLER_VARS" ]; then
+  echo "TARGET_DOPPLER_VARS is blank"
+  exit
+
+# So we have target_doppler_vars, lets split them out, then fetch and export the value from doppler
+IFS=',' read -ra VARS <<< "$TARGET_DOPPLER_VARS"
+
+for VAR in "${VARS[@]}"; do
+  echo "Fetching $VAR from doppler"
+  VALUE=$(doppler secrets get $VAR --plain)
+  # export the env var to >> $BP_DIR/export
+  echo "export $VAR=$VALUE" >> $BP_DIR/export
+done
+fi
+
+
 

--- a/bin/compile
+++ b/bin/compile
@@ -74,9 +74,6 @@ cd "$BUILD_DIR" || exit
 
 export DOPPLER_TOKEN=$(cat $ENV_DIR/DOPPLER_TOKEN)
 
-# echo DOPPLER_TOKEN
-echo "Quick test: $DOPPLER_TOKEN"
-
 # Helper system to deal with heroku not dealing well with heroku-prebuild and yarn in the nodejs package
 TARGET_DOPPLER_VARS=$(cat $ENV_DIR/TARGET_DOPPLER_VARS)
 echo "TARGET_DOPPLER_VARS: $TARGET_DOPPLER_VARS"
@@ -88,11 +85,11 @@ echo "Found TARGET_DOPPLER_VARS, attempting to extract and process..."
 
 # So we have target_doppler_vars, lets split them out, then fetch and export the value from doppler
 IFS=',' # Set the Internal Field Separator to comma
-for VAR in $TARGET_DOPPLER_VARS; do # Iterate over the variables
+for VAR in $TARGET_DOPPLER_VARS; do 
   echo "Fetching $VAR from doppler"
   VALUE=$($BUILD_DIR/vendor/doppler/doppler secrets get $VAR --plain)
   # export the env var to >> $BP_DIR/export
-  echo "export $VAR=$VALUE" >> $BP_DIR/export
+  echo "export $VAR=$VALUE" > "$BP_DIR/export"
 done
 
 

--- a/bin/compile
+++ b/bin/compile
@@ -82,7 +82,6 @@ if [ -z "$TARGET_DOPPLER_VARS" ]; then
 fi
 
 echo "Found TARGET_DOPPLER_VARS, attempting to extract and process..."
-# BUILD_DIR=${1:-}
 BP_DIR=$(cd "$(dirname "${0:-}")"; cd ..; pwd)
 
 # So we have target_doppler_vars, lets split them out, then fetch and export the value from doppler

--- a/bin/compile
+++ b/bin/compile
@@ -82,7 +82,7 @@ if [ -z "$TARGET_DOPPLER_VARS" ]; then
 fi
 
 echo "Found TARGET_DOPPLER_VARS, attempting to extract and process..."
-BUILD_DIR=${1:-}
+# BUILD_DIR=${1:-}
 BP_DIR=$(cd "$(dirname "${0:-}")"; cd ..; pwd)
 
 # So we have target_doppler_vars, lets split them out, then fetch and export the value from doppler

--- a/bin/compile
+++ b/bin/compile
@@ -89,7 +89,7 @@ echo "Found TARGET_DOPPLER_VARS, attempting to extract and process..."
 IFS=',' # Set the Internal Field Separator to comma
 for VAR in $TARGET_DOPPLER_VARS; do # Iterate over the variables
   echo "Fetching $VAR from doppler"
-  VALUE=$($BUILD_DIR/vendor/dopplerdoppler secrets get $VAR --plain)
+  VALUE=$($BUILD_DIR/vendor/doppler/doppler secrets get $VAR --plain)
   # export the env var to >> $BP_DIR/export
   echo "export $VAR=$VALUE" >> $BP_DIR/export
 done

--- a/bin/compile
+++ b/bin/compile
@@ -75,7 +75,9 @@ cd "$BUILD_DIR" || exit
 DOPPLER_TOKEN=$(cat $ENV_DIR/DOPPLER_TOKEN)
 
 # Helper system to deal with heroku not dealing well with heroku-prebuild and yarn in the nodejs package
+echo "Checking if we have any TARGET_DOPPLER_VARS"
 TARGET_DOPPLER_VARS=$(cat $ENV_DIR/TARGET_DOPPLER_VARS)
+echo "TARGET_DOPPLER_VARS: $TARGET_DOPPLER_VARS"
 if [ -z "$TARGET_DOPPLER_VARS" ]; then
   echo "TARGET_DOPPLER_VARS is blank"
   exit

--- a/bin/compile
+++ b/bin/compile
@@ -80,6 +80,8 @@ if [ -z "$TARGET_DOPPLER_VARS" ]; then
   echo "TARGET_DOPPLER_VARS is blank"
   exit
 
+echo "Found TARGET_DOPPLER_VARS, attempting to extract and process..."
+
 # So we have target_doppler_vars, lets split them out, then fetch and export the value from doppler
 IFS=',' read -ra VARS <<< "$TARGET_DOPPLER_VARS"
 

--- a/bin/compile
+++ b/bin/compile
@@ -81,6 +81,7 @@ echo "TARGET_DOPPLER_VARS: $TARGET_DOPPLER_VARS"
 if [ -z "$TARGET_DOPPLER_VARS" ]; then
   echo "TARGET_DOPPLER_VARS is blank"
   exit
+fi
 
 echo "Found TARGET_DOPPLER_VARS, attempting to extract and process..."
 
@@ -99,7 +100,7 @@ for VAR in "${VARS[@]}"; do
   # export the env var to >> $BP_DIR/export
   echo "export $VAR=$VALUE" >> $BP_DIR/export
 done
-fi
+
 
 
 

--- a/bin/compile
+++ b/bin/compile
@@ -74,6 +74,7 @@ cd "$BUILD_DIR" || exit
 
 if [ -f "$ENV_DIR/DOPPLER_TOKEN" ]; then
   export DOPPLER_TOKEN=$(cat $ENV_DIR/DOPPLER_TOKEN)
+fi
 
 # Helper system to deal with heroku not dealing well with heroku-prebuild and yarn in the nodejs package
 if [ -z "$ENV_DIR/TARGET_DOPPLER_VARS" ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -89,14 +89,7 @@ echo "Found TARGET_DOPPLER_VARS, attempting to extract and process..."
 IFS=',' # Set the Internal Field Separator to comma
 for VAR in $TARGET_DOPPLER_VARS; do # Iterate over the variables
   echo "Fetching $VAR from doppler"
-  VALUE=$(doppler secrets get $VAR --plain)
-  # export the env var to >> $BP_DIR/export
-  echo "export $VAR=$VALUE" >> $BP_DIR/export
-done
-
-for VAR in "${VARS[@]}"; do
-  echo "Fetching $VAR from doppler"
-  VALUE=$(doppler secrets get $VAR --plain)
+  VALUE=$($BUILD_DIR/vendor/dopplerdoppler secrets get $VAR --plain)
   # export the env var to >> $BP_DIR/export
   echo "export $VAR=$VALUE" >> $BP_DIR/export
 done


### PR DESCRIPTION
This PR updates the build pack to support injecting specifically named variables via `TARGET_DOPPLER_VARS`.  This means we can have certain variables injected in to any additional buildpacks that need these environment variables, but are then removed (as per Heroku's build process) come deployment. 

This is only required internally for some older applications which hopefully shouldn't be used in 6 months time, but means we can ensure we're building them in a more secure and locked-down manner. 