### PR TITLE
Exit script early if DOPPLER_TOKEN isnt set

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -74,6 +74,9 @@ cd "$BUILD_DIR" || exit
 
 if [ -f "$ENV_DIR/DOPPLER_TOKEN" ]; then
   export DOPPLER_TOKEN=$(cat $ENV_DIR/DOPPLER_TOKEN)
+else
+  # Allows us to preset TARGET_DOPPLER_VARS in the environment without risk of error.
+  exit;
 fi
 
 # Helper system to deal with heroku not dealing well with heroku-prebuild and yarn in the nodejs package


### PR DESCRIPTION
An edge case can arise if have `TARGET_DOPPLER_VARS` set but not `DOPPLER_TOKEN`, meaning an error will be generated. Adding this `else` clause to the `if` check means we'll prematurely exit and continue on merrily if no `DOPPLER_TOKEN` is set. 